### PR TITLE
package.json: fixed path to main

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "homepage": "https://www.gitbook.com",
     "description": "CLI to generate books and documentation using gitbook",
-    "main": "lib/index.js",
+    "main": "bin/gitbook.js",
     "dependencies": {
         "q": "1.4.1",
         "lodash": "3.10.1",


### PR DESCRIPTION
The [main](https://docs.npmjs.com/files/package.json#main) entry point of ```package.json``` points to not-existent path. Following code 

```
require('gitbook-cli');
```
then ends with exception
```
Error: Cannot find module 'gitbook-cli'
```

It should be fixed by pointing ```main``` to ```bin/gitbook.js```. 