### PR TITLE
Fix a minor programming slip-up in the last release

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ function ensureVersion(bookRoot, version, opts) {
 
     // If not defined, load version required from book.json
     .then(function() {
-        if (version) return;
+        if (version) return version;
         return bookVersion(bookRoot);
     })
 


### PR DESCRIPTION
The last change to ensureVersion added a return value to one of the
anonymous function, but forgot to update an existing code path to also
return a value. This change fixes that oversight.