### PR TITLE
bump bash-color to version that has a license

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "commander": "2.9.0",
         "optimist": "0.6.1",
         "fs-extra": "0.26.5",
-        "bash-color": "0.0.3",
+        "bash-color": "0.0.4",
         "npm": "3.7.5",
         "user-home": "2.0.0"
     },


### PR DESCRIPTION
Version currently being used does not have a license making it difficult for companies to use.