### PR TITLE
bump lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "main": "bin/gitbook.js",
     "dependencies": {
         "q": "1.5.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "semver": "5.3.0",
         "npmi": "1.0.1",
         "tmp": "0.0.31",


### PR DESCRIPTION
Bump lodash to 4.17.5 because previous versions are affected by this security issue https://nvd.nist.gov/vuln/detail/CVE-2018-3721