### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,16 +5,16 @@
     "description": "CLI to generate books and documentation using gitbook",
     "main": "bin/gitbook.js",
     "dependencies": {
-        "q": "1.5.0",
-        "lodash": "4.17.4",
+        "q": "1.5.1",
+        "lodash": "4.17.11",
         "semver": "5.3.0",
         "npmi": "1.0.1",
-        "tmp": "0.0.31",
+        "tmp": "0.0.33",
         "commander": "2.11.0",
         "optimist": "0.6.1",
         "fs-extra": "3.0.1",
         "bash-color": "0.0.4",
-        "npm": "5.1.0",
+        "npm": "5.10.0",
         "user-home": "2.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Updates dependency `patch` ranges.

PR also does a `minor` bump to NPM because we use this library in our monorepo and older versions break publishing with `Lerna` ([ref](https://github.com/lerna/lerna/issues/1573))